### PR TITLE
restricted new exchange request when item is already in exchange table

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,7 @@ class ItemsController < ApplicationController
 
   # GET /items/:id
   def show
+    @exchanges = Exchange.all
   end
 
   # GET /items/new

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -61,6 +61,8 @@
             <%= link_to 'View exchange requests', '#', class: "btn btn-success mb-4", style: "width: 100%" %>
             <div><i class="far fa-edit mr-2"></i><%= link_to 'Edit Listing', edit_item_path(@item), class: "text-decoration-none" %></div>
             <div class="delete mt-2"><i class="far fa-trash-alt mr-2 text-danger"></i><%= link_to 'Delete', @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "text-danger text-decoration-none" %></div>
+          <% elsif @exchanges.map { |exchange| exchange.item_id }.include?(@item.id) %>
+            <div>Sorry! Not available anymore</div>
           <% else %>
             <div class="exchange-form mt-4">
               <h3>Exchange request</h3>

--- a/db/migrate/20211204035514_add_requested_to_exchanges.rb
+++ b/db/migrate/20211204035514_add_requested_to_exchanges.rb
@@ -1,0 +1,5 @@
+class AddRequestedToExchanges < ActiveRecord::Migration[6.0]
+  def change
+    add_column :exchanges, :requested, :boolean
+  end
+end

--- a/db/migrate/20211204035542_add_approved_to_exchanges.rb
+++ b/db/migrate/20211204035542_add_approved_to_exchanges.rb
@@ -1,0 +1,5 @@
+class AddApprovedToExchanges < ActiveRecord::Migration[6.0]
+  def change
+    add_column :exchanges, :approved, :boolean
+  end
+end

--- a/db/migrate/20211204035606_add_completed_to_exchanges.rb
+++ b/db/migrate/20211204035606_add_completed_to_exchanges.rb
@@ -1,0 +1,5 @@
+class AddCompletedToExchanges < ActiveRecord::Migration[6.0]
+  def change
+    add_column :exchanges, :completed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_27_093512) do
+ActiveRecord::Schema.define(version: 2021_12_04_035606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,9 @@ ActiveRecord::Schema.define(version: 2021_11_27_093512) do
     t.bigint "item_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "requested"
+    t.boolean "approved"
+    t.boolean "completed"
     t.index ["item_id"], name: "index_exchanges_on_item_id"
     t.index ["user_id"], name: "index_exchanges_on_user_id"
   end


### PR DESCRIPTION
only 1 feature added. If item already is in exchange model, to not allow other exchanges to be requested. 