### PR TITLE
Add profile image

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,6 +1,7 @@
 .avatar {
   width: 40px;
   border-radius: 50%;
+  cursor: pointer;
 }
 .avatar-large {
   width: 56px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,10 +17,10 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :phone_number])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :phone_number, :photo])
 
     # For additional in app/views/devise/registrations/edit.html.erb
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :phone_number])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :phone_number, :photo])
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :exchanges
   has_many :items
+  has_one_attached :photo
 
   validates :name, length: { minimum: 3, maximum: 50 }, presence: true
   validates :phone_number, length: { minimum: 8, maximum: 14 }, presence: true

--- a/app/views/components/_navbar.html.erb
+++ b/app/views/components/_navbar.html.erb
@@ -28,10 +28,13 @@
           <%= link_to "Create New Listing", new_item_path, class: "nav-link text-light" %>
         </li>
         <li class="nav-item dropdown">
-          <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% if current_user.photo.attached? %>
+            <%= cl_image_tag current_user.photo.key, height: 40, width: 40, crop: :fill, class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% else %>
+            <%= image_tag "http://placekitten.com/g/200/200", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% end %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-            <%# link_to "Action", "#", class: "dropdown-item" %>
-            <%# link_to "Another action", "#", class: "dropdown-item" %>
+            <%= link_to "Edit profile", edit_user_registration_path, class: "dropdown-item text-success" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item text-success" %>
           </div>
         </li>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,12 +6,14 @@
       <%= f.error_notification %>
 
       <div class="form-inputs">
-        <%= f.input :email, required: true, autofocus: true %>
+        <%= f.input :name, required: true, autofocus: true %>
+        <%= f.input :email, required: true %>
 
         <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
           <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
         <% end %>
 
+        <%= f.input :phone_number, required: true %>
         <%= f.input :password,
                     hint: "leave it blank if you don't want to change it",
                     required: false,
@@ -19,6 +21,7 @@
         <%= f.input :password_confirmation,
                     required: false,
                     input_html: { autocomplete: "new-password" } %>
+        <%= f.input :photo, as: :file, label: 'Upload Profile Picture (Optional)' %>
         <%= f.input :current_password,
                     hint: "we need your current password to confirm your changes",
                     required: true,
@@ -26,13 +29,13 @@
       </div>
 
       <div class="form-actions">
-        <%= f.button :submit, "Update" %>
+        <%= f.button :submit, "Update", class: 'btn btn-success' %>
       </div>
     <% end %>
 
     <h3>Cancel my account</h3>
 
-    <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+    <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'text-danger' %></p>
 
     <%= link_to "Back", :back %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,9 @@
           <%= f.input :password_confirmation,
                       required: true,
                       input_html: { autocomplete: "new-password" } %>
+          <%= f.input :photo,
+                      as: :file,
+                      label: 'Upload Profile Picture (Optional)' %>
         </div>
 
         <div class="form-actions">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -56,7 +56,7 @@
         <div class="card-body m-2">
           <div class="card-title d-flex justify-content-start align-items-center border-bottom mb-3">
             <% if @item.user.photo.attached? %>
-              <%= cl_image_tag @item.user.photo.key, class: "avatar mb-3" %>
+              <%= cl_image_tag @item.user.photo.key, height: 40, width: 40, crop: :fill, class: "avatar mb-3" %>
             <% else %>
               <%= image_tag "http://placekitten.com/g/200/200", class: "avatar mb-3" %>
             <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -55,7 +55,11 @@
       <div class="card item-show-card mb-3 mt-4">
         <div class="card-body m-2">
           <div class="card-title d-flex justify-content-start align-items-center border-bottom mb-3">
-            <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar mb-3" %>
+            <% if @item.user.photo.attached? %>
+              <%= cl_image_tag @item.user.photo.key, class: "avatar mb-3" %>
+            <% else %>
+              <%= image_tag "http://placekitten.com/g/200/200", class: "avatar mb-3" %>
+            <% end %>
             <h5 class="ml-2 mb-3"><%= @item.user.name %></h5>
           </div>
           <% if policy(@item).update? && policy(@item).destroy? %>


### PR DESCRIPTION
@maynard242 @AMNoronha @Darthyeh1990 

Users can now upload a profile image. This is optional for them, if no image is uploaded, a placeholder image will be used instead. 

- Updated navbar avatar to display current user's profile image.
- Updated items#show page's avatar to display item owner's profile image.
- Added 'Edit profile' to navbar avatar dropdown menu.

<img width="215" alt="Screenshot 2021-12-07 at 10 52 32 PM" src="https://user-images.githubusercontent.com/86341373/145052111-97a52ba6-86b7-47e3-9d6c-247a40c8d025.png">
<img width="1264" alt="Screenshot 2021-12-07 at 10 53 41 PM" src="https://user-images.githubusercontent.com/86341373/145052136-7f5766d6-a1df-46b9-9338-e239e92f4237.png">
<img width="662" alt="Screenshot 2021-12-07 at 10 59 00 PM" src="https://user-images.githubusercontent.com/86341373/145052820-9c5ccee2-00d5-407b-88fe-94e34bb891c1.png">
