### PR TITLE
Scroll to top button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,4 @@
 @import "pages/index";
 @import "config/text";
 @import "components/index";
+@import "components/scroll_top_btn"

--- a/app/assets/stylesheets/components/_scroll_top_btn.scss
+++ b/app/assets/stylesheets/components/_scroll_top_btn.scss
@@ -1,0 +1,33 @@
+.top-link {
+  transition: all .25s ease-in-out;
+  position: fixed;
+  bottom: 20px;
+  right: 30px;
+  display: inline-flex;
+  cursor: pointer;
+  z-index: 99;
+
+  &.show {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  &.hide {
+    visibility: hidden;
+    opacity: 0;
+  }
+
+	.fa-chevron-circle-up {
+		color: $dark-green;
+    opacity: 0.8;
+	}
+
+	&:hover {
+    text-decoration: none;
+
+		.fa-chevron-circle-up {
+			color: $dark-green;
+      opacity: 1;
+		}
+	}
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,10 +32,14 @@ import { initAutocomplete } from '../plugins/init_autocomplete';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import 'aos/dist/aos.css';
 import AOS from 'aos';
+import { scrollFunc } from '../plugins/scroll_to_top';
+import { initscrollToTop } from '../plugins/scroll_to_top';
 
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   initMapbox();
   initAutocomplete();
   AOS.init();
+  scrollFunc();
+  initscrollToTop();
 });

--- a/app/javascript/plugins/scroll_to_top.js
+++ b/app/javascript/plugins/scroll_to_top.js
@@ -1,0 +1,43 @@
+// Set a variable for our button element.
+const scrollToTopBtn = document.getElementById('scrollToTop');
+
+// Let's set up a function that shows our scroll-to-top button if we scroll beyond the height of the initial window.
+const scrollFunc = () => {
+  // Get the current scroll value
+  let y = window.scrollY;
+
+  // If the scroll value is greater than the window height, let's add a class to the scroll-to-top button to show it!
+  if (y > 0) {
+    scrollToTopBtn.className = "top-link show";
+  } else {
+    scrollToTopBtn.className = "top-link hide";
+  }
+};
+
+window.addEventListener("scroll", scrollFunc);
+
+const scrollToTop = () => {
+  // Let's set a variable for the number of pixels we are from the top of the document.
+  const c = document.documentElement.scrollTop || document.body.scrollTop;
+
+  // If that number is greater than 0, we'll scroll back to 0, or the top of the document.
+  // We'll also animate that scroll with requestAnimationFrame:
+  // https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
+  if (c > 0) {
+    window.requestAnimationFrame(scrollToTop);
+    // ScrollTo takes an x and a y coordinate.
+    // Increase the '10' value to get a smoother/slower scroll!
+    window.scrollTo(0, c - c / 10);
+  }
+};
+
+// When the button is clicked, run our ScrolltoTop function above!
+const initscrollToTop = () => {
+  scrollToTopBtn.onclick = function (e) {
+    e.preventDefault();
+    scrollToTop();
+  }
+};
+
+export { scrollFunc };
+export { initscrollToTop };

--- a/app/views/components/_navbar.html.erb
+++ b/app/views/components/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-sm navbar-light navbar-lewagon">
+<nav class="navbar navbar-expand-sm navbar-light navbar-lewagon sticky-top">
 
     <a class="navbar-brand" id="brand" href="/">
       <span><%= image_tag "recycleme-logo.svg", class: "d-inline-block align-center", alt: "" %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,5 @@
 <div class="container-fluid align-justify-center">
+  <a href="" class="top-link hide" id="scrollToTop"><i class="fas fa-3x fa-chevron-circle-up"></i></a>
 
   <div class="text-center py-3">
     <h1 class="py-1 my-3">3 Easy Steps<br>


### PR DESCRIPTION
@maynard242 @AMNoronha @Darthyeh1990 
- Made the navbar stick to top while scrolling (for easier access to search and links on the navbar)
- Added a scroll to top button for home page (to scroll back up easily)
<img width="1280" alt="Screenshot 2021-12-09 at 10 24 31 PM" src="https://user-images.githubusercontent.com/86341373/145414374-77646ac1-b561-496a-89d2-e73f02f25b82.png">

