### PR TITLE
Fixed item messages on items#show page

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,7 @@ class ItemsController < ApplicationController
   # GET /items/:id
   def show
     @exchanges = Exchange.all
+    @exchange = @exchanges.find_by(item_id: @item.id)
   end
 
   # GET /items/new

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -71,11 +71,13 @@
           </div>
           <% if policy(@item).update? && policy(@item).destroy? %>
             <%= link_to 'View exchange requests', exchanges_path, class: "btn btn-primary mb-4", style: "width: 100%" %>
-            <div><i class="far fa-edit mr-2"></i><%= link_to 'Edit Listing', edit_item_path(@item), class: "text-decoration-none" %></div>
+            <% if @exchange.completed %>
+              <div>Item successfully recycled!</div>
+            <% else %>
+              <div><i class="far fa-edit mr-2"></i><%= link_to 'Edit Listing', edit_item_path(@item), class: "text-decoration-none" %></div>
+            <% end %>
             <div class="delete mt-2"><i class="far fa-trash-alt mr-2 text-danger"></i><%= link_to 'Delete', @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "text-danger text-decoration-none" %></div>
-          <% elsif @exchanges.map { |exchange| exchange.item_id }.include?(@item.id) %>
-            <div>Request pending confirmation...</div>
-          <% else %>
+          <% elsif @exchange.nil? %>
             <div class="exchange-form mt-4">
               <h3>Exchange request</h3>
                 <div class="mt-3">
@@ -87,6 +89,14 @@
                   <% end %>
                 </div>
             </div>
+          <% elsif @exchange.user_id == current_user.id && @exchange.completed %>
+            <div>Exchange is completed!</div>
+          <% elsif @exchange.user_id == current_user.id && @exchange.approved %>
+            <div>Your request is accepted!</div>
+          <% elsif @exchange.user_id == current_user.id %>
+            <div>Your request is pending...</div>
+          <% else %>
+            <div>Sorry... Item is no longer available!</div>
           <% end %>
         </div>
       </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -70,13 +70,19 @@
               <h5 class="ml-2 mb-3"><%= @item.user.name %></h5>
           </div>
           <% if policy(@item).update? && policy(@item).destroy? %>
-            <%= link_to 'View exchange requests', exchanges_path, class: "btn btn-primary mb-4", style: "width: 100%" %>
-            <% if @exchange.completed %>
+            <% if @exchange.nil? %>
+              <%= link_to 'View exchange requests', exchanges_path, class: "btn btn-primary mb-4", style: "width: 100%" %>
+              <div><i class="far fa-edit mr-2"></i><%= link_to 'Edit Listing', edit_item_path(@item), class: "text-decoration-none" %></div>
+              <div class="delete mt-2"><i class="far fa-trash-alt mr-2 text-danger"></i><%= link_to 'Delete', @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "text-danger text-decoration-none" %></div>
+            <% elsif @exchange.completed %>
               <div>Item successfully recycled!</div>
+              <div class="delete mt-2"><i class="far fa-trash-alt mr-2 text-danger"></i><%= link_to 'Delete', @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "text-danger text-decoration-none" %></div>
+            <% elsif @exchange.approved %>
+              <%= link_to 'You accepted the request!', exchanges_path, class: "btn btn-primary mb-4", style: "width: 100%" %>
             <% else %>
+              <%= link_to 'You have an exchange request!', exchanges_path, class: "btn btn-primary mb-4", style: "width: 100%" %>
               <div><i class="far fa-edit mr-2"></i><%= link_to 'Edit Listing', edit_item_path(@item), class: "text-decoration-none" %></div>
             <% end %>
-            <div class="delete mt-2"><i class="far fa-trash-alt mr-2 text-danger"></i><%= link_to 'Delete', @item, method: :delete, data: { confirm: 'Are you sure?' }, class: "text-danger text-decoration-none" %></div>
           <% elsif @exchange.nil? %>
             <div class="exchange-form mt-4">
               <h3>Exchange request</h3>


### PR DESCRIPTION
- When user creates exchange request:
- User who created exchange sees this:
<img width="1280" alt="Screenshot 2021-12-10 at 7 58 59 PM" src="https://user-images.githubusercontent.com/86341373/145579978-63004930-a00d-47e7-bec7-51eedb72889f.png">
- Other users see this:
<img width="1280" alt="Screenshot 2021-12-10 at 9 19 21 PM" src="https://user-images.githubusercontent.com/86341373/145580217-670ec136-dfc0-4352-b1f5-028baa40f299.png">

- When item owner approves request:
<img width="1280" alt="Screenshot 2021-12-10 at 9 21 21 PM" src="https://user-images.githubusercontent.com/86341373/145580453-7bf1db0f-b0f7-4648-841d-9d9bbfb34368.png">
<img width="1280" alt="Screenshot 2021-12-10 at 9 29 20 PM" src="https://user-images.githubusercontent.com/86341373/145581524-7c4936ca-fd17-4f96-bd60-5dad19945986.png">

- When user completes collection of item
<img width="1280" alt="Screenshot 2021-12-10 at 6 41 44 PM" src="https://user-images.githubusercontent.com/86341373/145564082-79f44f47-9d9c-487b-a4bb-a7cbc6078e18.png">
- Item owner sees this:
<img width="1280" alt="Screenshot 2021-12-10 at 6 41 13 PM" src="https://user-images.githubusercontent.com/86341373/145564317-5e03c4fe-b291-4c25-bb95-7367884c714e.png">

